### PR TITLE
[리팩토링] LettuceLock -> RedissonLock + 기타 정리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'io.springfox:springfox-boot-starter:3.0.0'
 	implementation group: 'io.jsonwebtoken', name: 'jjwt', version: '0.9.1'
+	implementation 'org.redisson:redisson:3.25.0'
 
 	compileOnly 'org.projectlombok:lombok'
 //	compileOnly 'org.springframework.boot:spring-boot-devtools:3.1.0'

--- a/src/main/java/com/jhsfully/inventoryManagement/config/RedissonConfiguration.java
+++ b/src/main/java/com/jhsfully/inventoryManagement/config/RedissonConfiguration.java
@@ -1,0 +1,28 @@
+package com.jhsfully.inventoryManagement.config;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RedissonConfiguration {
+
+    @Value("${spring.redis.host}")
+    private String host;
+
+    @Value("${spring.redis.port}")
+    private String port;
+
+    private static final String REDIS_SERVER_PREFIX = "redis://";
+
+    @Bean
+    public RedissonClient redissonClient() {
+        Config config = new Config();
+        config.useSingleServer().setAddress(REDIS_SERVER_PREFIX + host + ":" + port);
+        return Redisson.create(config);
+    }
+
+}

--- a/src/main/java/com/jhsfully/inventoryManagement/dto/AuthDto.java
+++ b/src/main/java/com/jhsfully/inventoryManagement/dto/AuthDto.java
@@ -10,12 +10,14 @@ import java.util.stream.Collectors;
 public class AuthDto {
 
     @Getter
+    @NoArgsConstructor
     @AllArgsConstructor
     public static class SignIn{
         private String username;
         private String password;
     }
     @Getter
+    @NoArgsConstructor
     @AllArgsConstructor
     public static class SignUp{
         private String username;
@@ -26,6 +28,7 @@ public class AuthDto {
     }
 
     @Getter
+    @NoArgsConstructor
     @AllArgsConstructor
     public static class PasswordChangeRequest{
         private String username;
@@ -35,6 +38,7 @@ public class AuthDto {
     }
 
     @Getter
+    @NoArgsConstructor
     @AllArgsConstructor
     public static class PasswordInitializeRequest{
         private String username;
@@ -42,6 +46,7 @@ public class AuthDto {
     }
 
     @Getter
+    @NoArgsConstructor
     @AllArgsConstructor
     public static class UserChangeRequest{
         private String username;
@@ -51,6 +56,7 @@ public class AuthDto {
     }
 
     @Getter
+    @NoArgsConstructor
     @AllArgsConstructor
     @Builder
     public static class UserResponse{

--- a/src/main/java/com/jhsfully/inventoryManagement/dto/BomDto.java
+++ b/src/main/java/com/jhsfully/inventoryManagement/dto/BomDto.java
@@ -7,6 +7,7 @@ import java.util.List;
 public class BomDto {
 
     @Getter
+    @NoArgsConstructor
     @AllArgsConstructor
     @Builder
     public static class BomAddRequest{
@@ -16,6 +17,7 @@ public class BomDto {
     }
 
     @Getter
+    @NoArgsConstructor
     @AllArgsConstructor
     @Builder
     public static class BomUpdateRequest{

--- a/src/main/java/com/jhsfully/inventoryManagement/dto/ErrorResponse.java
+++ b/src/main/java/com/jhsfully/inventoryManagement/dto/ErrorResponse.java
@@ -4,8 +4,10 @@ import com.jhsfully.inventoryManagement.type.ErrorTypeInterface;
 import com.jhsfully.inventoryManagement.type.ProductErrorType;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 @AllArgsConstructor
 public class ErrorResponse{
 

--- a/src/main/java/com/jhsfully/inventoryManagement/dto/InboundDto.java
+++ b/src/main/java/com/jhsfully/inventoryManagement/dto/InboundDto.java
@@ -7,6 +7,7 @@ import java.time.LocalDateTime;
 public class InboundDto {
 
     @Getter
+    @NoArgsConstructor
     @AllArgsConstructor
     @Builder
     public static class InboundOuterAddRequest{
@@ -17,6 +18,7 @@ public class InboundDto {
     }
 
     @Getter
+    @NoArgsConstructor
     @AllArgsConstructor
     @Builder
     public static class InboundAddRequest{
@@ -28,6 +30,7 @@ public class InboundDto {
     }
 
     @Getter
+    @NoArgsConstructor
     @AllArgsConstructor
     @Builder
     public static class InboundResponse{

--- a/src/main/java/com/jhsfully/inventoryManagement/dto/OutboundDto.java
+++ b/src/main/java/com/jhsfully/inventoryManagement/dto/OutboundDto.java
@@ -8,6 +8,7 @@ import java.util.List;
 public class OutboundDto {
 
     @Getter
+    @NoArgsConstructor
     @AllArgsConstructor
     @Builder
     public static class OutboundAddRequest{
@@ -21,6 +22,7 @@ public class OutboundDto {
     }
 
     @Getter
+    @NoArgsConstructor
     @AllArgsConstructor
     public static class stock{
         private Long stockId;
@@ -28,6 +30,7 @@ public class OutboundDto {
     }
 
     @Getter
+    @NoArgsConstructor
     @AllArgsConstructor
     @Builder
     public static class OutboundDetailAddRequest{
@@ -39,6 +42,7 @@ public class OutboundDto {
     }
 
     @Getter
+    @NoArgsConstructor
     @AllArgsConstructor
     @Builder
     public static class OutboundResponse{
@@ -54,6 +58,7 @@ public class OutboundDto {
     }
 
     @Getter
+    @NoArgsConstructor
     @AllArgsConstructor
     @Builder
     public static class OutboundDetailResponse{

--- a/src/main/java/com/jhsfully/inventoryManagement/dto/PlanDto.java
+++ b/src/main/java/com/jhsfully/inventoryManagement/dto/PlanDto.java
@@ -7,6 +7,7 @@ import java.time.LocalDate;
 public class PlanDto {
 
     @Getter
+    @NoArgsConstructor
     @AllArgsConstructor
     @Builder
     public static class PlanAddRequest{
@@ -17,6 +18,7 @@ public class PlanDto {
     }
 
     @Getter
+    @NoArgsConstructor
     @AllArgsConstructor
     @Builder
     public static class PlanUpdateRequest{
@@ -27,6 +29,7 @@ public class PlanDto {
     }
 
     @Getter
+    @NoArgsConstructor
     @AllArgsConstructor
     @Builder
     public static class PlanResponse{

--- a/src/main/java/com/jhsfully/inventoryManagement/dto/ProductDto.java
+++ b/src/main/java/com/jhsfully/inventoryManagement/dto/ProductDto.java
@@ -6,6 +6,7 @@ import lombok.*;
 public class ProductDto {
 
     @Getter
+    @NoArgsConstructor
     @AllArgsConstructor
     @Builder
     public static class ProductAddRequest{
@@ -16,6 +17,7 @@ public class ProductDto {
     }
 
     @Getter
+    @NoArgsConstructor
     @AllArgsConstructor
     @Builder
     public static class ProductUpdateRequest{

--- a/src/main/java/com/jhsfully/inventoryManagement/dto/PurchaseDto.java
+++ b/src/main/java/com/jhsfully/inventoryManagement/dto/PurchaseDto.java
@@ -7,6 +7,7 @@ import java.time.LocalDateTime;
 public class PurchaseDto {
 
     @Getter
+    @NoArgsConstructor
     @AllArgsConstructor
     @Builder
     public static class PurchaseAddRequest{
@@ -18,6 +19,7 @@ public class PurchaseDto {
     }
 
     @Getter
+    @NoArgsConstructor
     @AllArgsConstructor
     @Builder
     public static class PurchaseResponse{

--- a/src/main/java/com/jhsfully/inventoryManagement/dto/StocksDto.java
+++ b/src/main/java/com/jhsfully/inventoryManagement/dto/StocksDto.java
@@ -7,6 +7,7 @@ import java.time.LocalDate;
 public class StocksDto{
 
     @Getter
+    @NoArgsConstructor
     @AllArgsConstructor
     @Builder
     public static class StockAddRequest{
@@ -17,6 +18,7 @@ public class StocksDto{
     }
 
     @Getter
+    @NoArgsConstructor
     @AllArgsConstructor
     public static class StockGroupResponse{ //Use Inner Dto
         private Long productId;
@@ -26,6 +28,7 @@ public class StocksDto{
 
     @Getter
     @Setter
+    @NoArgsConstructor
     @AllArgsConstructor
     @Builder
     public static class StockResponse{ //Client Return Dto
@@ -40,6 +43,7 @@ public class StocksDto{
     }
 
     @Getter
+    @NoArgsConstructor
     @AllArgsConstructor
     @Builder
     public static class StockResponseLot{

--- a/src/main/java/com/jhsfully/inventoryManagement/dto/TokenDto.java
+++ b/src/main/java/com/jhsfully/inventoryManagement/dto/TokenDto.java
@@ -6,6 +6,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter
+@NoArgsConstructor
 @AllArgsConstructor
 public class TokenDto {
     private String accessToken;

--- a/src/main/java/com/jhsfully/inventoryManagement/facade/InboundFacade.java
+++ b/src/main/java/com/jhsfully/inventoryManagement/facade/InboundFacade.java
@@ -5,18 +5,18 @@ import com.jhsfully.inventoryManagement.dto.PurchaseDto;
 import com.jhsfully.inventoryManagement.dto.StocksDto;
 import com.jhsfully.inventoryManagement.exception.InboundException;
 import com.jhsfully.inventoryManagement.exception.StocksException;
+import com.jhsfully.inventoryManagement.lock.ProcessLock;
 import com.jhsfully.inventoryManagement.service.InboundInterface;
 import com.jhsfully.inventoryManagement.service.OutboundInterface;
 import com.jhsfully.inventoryManagement.service.PurchaseInterface;
 import com.jhsfully.inventoryManagement.service.StocksInterface;
 import com.jhsfully.inventoryManagement.type.InboundErrorType;
+import com.jhsfully.inventoryManagement.type.LockType;
 import com.jhsfully.inventoryManagement.type.StocksErrorType;
+import java.time.LocalDate;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.time.LocalDate;
-import java.util.List;
 
 //서비스간 참조를 막기위한 중간층.
 //Controller => Facade => Services => Repositories
@@ -60,23 +60,19 @@ public class InboundFacade {
         return inbound.getId();
     }
 
-    public void cancelInbound(Long id){
-        //입고를 지운다. => 재고를 지운다. (조건 : 출고 이력이 없어야 함)
-        InboundDto.InboundResponse inboundResponse = inboundService.getInbound(id);
-        StocksDto.StockResponseLot stockResponse = stocksService.getStock(
-                inboundResponse.getStockId()
-        );
+    @ProcessLock(group = LockType.INBOUND_OUTBOUND, key = "#stockId")
+    public void cancelInbound(Long inboundId, Long stockId){
 
         //출고 이력 미존재 여부 검증
-        if(outboundService.countByStock(stockResponse.getId()) > 0){
+        if(outboundService.countByStock(stockId) > 0){
             throw new StocksException(StocksErrorType.STOCKS_OCCURRED_OUTBOUND);
         }
 
         //cascade옵션을 지정하지 않았기에, 수동 할당해제 후 삭제해야함.
-        stocksService.releaseInbound(stockResponse.getId());
+        stocksService.releaseInbound(stockId);
 
-        inboundService.deleteInbound(inboundResponse.getId());
-        stocksService.deleteStock(stockResponse.getId());
+        inboundService.deleteInbound(inboundId);
+        stocksService.deleteStock(stockId);
 
     }
 

--- a/src/main/java/com/jhsfully/inventoryManagement/lock/ProcessLock.java
+++ b/src/main/java/com/jhsfully/inventoryManagement/lock/ProcessLock.java
@@ -9,5 +9,7 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface ProcessLock {
     String key() default "";
-    String value() default "";
+    String group() default "";
+    long waitTime() default 3L; //lock을 취득할 때까지 대기할 시간.
+    long leaseTime() default 2L; //unlock이 수행되기 전까지 lock을 점유하는 시간.
 }

--- a/src/main/java/com/jhsfully/inventoryManagement/lock/ProcessLockAspect.java
+++ b/src/main/java/com/jhsfully/inventoryManagement/lock/ProcessLockAspect.java
@@ -1,118 +1,54 @@
 package com.jhsfully.inventoryManagement.lock;
 
+import com.jhsfully.inventoryManagement.lock.service.AopTransactionService;
+import com.jhsfully.inventoryManagement.lock.service.RedissonLockService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.reflect.MethodSignature;
-import org.springframework.core.DefaultParameterNameDiscoverer;
-import org.springframework.core.ParameterNameDiscoverer;
-import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.expression.ExpressionParser;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
 import org.springframework.stereotype.Component;
 
-import java.lang.reflect.Field;
-import java.time.Duration;
-import java.util.Arrays;
-
+@Slf4j
 @Aspect
 @Component
+@RequiredArgsConstructor
 public class ProcessLockAspect {
 
-    private RedisTemplate<String, String> redisTemplate;
-    private DefaultParameterNameDiscoverer parameterNameDiscoverer;
-
-    public ProcessLockAspect(RedisTemplate<String, String> redisTemplate){
-        this.redisTemplate = redisTemplate;
-        this.parameterNameDiscoverer = new DefaultParameterNameDiscoverer();
-    }
+    private final RedissonLockService redissonLockService;
+    private final AopTransactionService aopTransactionService;
 
     @Around("@annotation(processLock)")
-    public Object applyProcess(ProceedingJoinPoint joinPoint, ProcessLock processLock) throws Throwable {
-        String valueString = processLock.value();
-        String keyString = getKeyString(joinPoint, processLock.key());
+    public Object lock(ProceedingJoinPoint joinPoint, ProcessLock processLock) throws Throwable {
 
-        //ex) lockKey = 'lock:purchase-inbound-1'
-        String lockKey = "lock:" + valueString + "-" + keyString;
+        String keyExpression = processLock.key();
+        String key = getKey(keyExpression, joinPoint);
+        String group = processLock.group();
 
-        System.out.println(lockKey);
-
-        boolean acquired = false;
-
-        try{
-            acquired = getLock(lockKey, 2_000L);
-            if(acquired){
-                return joinPoint.proceed();
-            }else{
-                throw new IllegalStateException("Process is Locked!!");
-            }
-        }finally {
-            if(acquired){
-                releaseLock(lockKey);
-            }
+        redissonLockService.lock(group, key, processLock.waitTime(), processLock.leaseTime());
+        try {
+            return aopTransactionService.proceed(joinPoint);
+        } finally {
+            redissonLockService.unlock(group, key);
         }
     }
 
-    private String getKeyString(ProceedingJoinPoint joinPoint, String path){
-
+    private String getKey(String expression, ProceedingJoinPoint joinPoint) {
+        StandardEvaluationContext context = new StandardEvaluationContext();
         Object[] args = joinPoint.getArgs();
-
-        MethodSignature methodSignature = (MethodSignature) joinPoint.getSignature();
-        String[] parameterNames = parameterNameDiscoverer.getParameterNames(methodSignature.getMethod());
-
-        String[] parameterPath = path.split("\\."); // 점(.)을 기준으로 나눔
-
-        System.out.println("parameters : ");
-        System.out.println(Arrays.toString(parameterNames));
-        System.out.println(Arrays.toString(parameterPath));
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        String[] parameterNames = signature.getParameterNames();
 
         for (int i = 0; i < parameterNames.length; i++) {
-            if(parameterNames[i].equals(parameterPath[0])){
-
-                if(parameterPath.length == 1){ //멤버 변수가 없는 경우.
-                    return args[i] + "";
-                }
-
-                try {
-                    return findFieldValue(1, args[i], parameterPath);
-                }catch (Exception e){
-                    new RuntimeException("데이터 구조가 올바르지 않습니다.");
-                }
-            }
+            context.setVariable(parameterNames[i], args[i]);
         }
 
-        return "";
-    }
-
-    private String findFieldValue(int idx, Object arg, String[] fields) throws NoSuchFieldException, IllegalAccessException {
-        Field field = arg.getClass().getDeclaredField(fields[idx]);
-        field.setAccessible(true);
-
-        Object fieldValue = field.get(arg);
-
-        if(idx == fields.length - 1){
-            return fieldValue + "";
-        }else{
-            return findFieldValue(idx + 1, fieldValue, fields);
-        }
-    }
-
-    private boolean getLock(String lockKey, Long timeout) throws InterruptedException {
-        Long startTime = System.currentTimeMillis();
-        Long endTime = startTime + timeout;
-        boolean result = false;
-
-        while(System.currentTimeMillis() < endTime){
-            result = redisTemplate.opsForValue().setIfAbsent(lockKey, "locked", Duration.ofMillis(15_000L));
-            if(result){
-                break;
-            }
-            Thread.sleep(100);
-        }
-        return result;
-    }
-
-    private void releaseLock(String lockKey){
-        redisTemplate.delete(lockKey);
+        ExpressionParser parser = new SpelExpressionParser();
+        return parser.parseExpression(expression).getValue(context, String.class);
     }
 
 }

--- a/src/main/java/com/jhsfully/inventoryManagement/lock/service/AopTransactionService.java
+++ b/src/main/java/com/jhsfully/inventoryManagement/lock/service/AopTransactionService.java
@@ -1,0 +1,14 @@
+package com.jhsfully.inventoryManagement.lock.service;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class AopTransactionService {
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public Object proceed(ProceedingJoinPoint joinPoint) throws Throwable {
+        return joinPoint.proceed();
+    }
+}

--- a/src/main/java/com/jhsfully/inventoryManagement/lock/service/RedissonLockService.java
+++ b/src/main/java/com/jhsfully/inventoryManagement/lock/service/RedissonLockService.java
@@ -1,0 +1,44 @@
+package com.jhsfully.inventoryManagement.lock.service;
+
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RedissonLockService {
+
+    private final RedissonClient redissonClient;
+
+    //group-key를 기준으로 lock을 획득함.
+    public void lock(Object group, Object key, long waitTime, long leaseTime)
+        throws InterruptedException {
+        RLock lock = redissonClient.getLock(getLockKey(group, key));
+        log.debug("Trying lock for group-key : {}", getLockKey(group, key));
+        try {
+            boolean isLock = lock.tryLock(waitTime, leaseTime, TimeUnit.SECONDS);
+            if (!isLock) {
+                log.error("Lock acquisition failed");
+                throw new RuntimeException();
+            }
+        } catch (InterruptedException e){ //쓰레드가 중단된 경우, Lock을 가져올 수 없음.
+            log.error("The thread is interrupted", e);
+            throw new InterruptedException();
+        }
+    }
+
+    //group-key를 기준으로 lock을 반환함.
+    public void unlock(Object group, Object key){
+        log.debug("Unlock for group-key : {}", getLockKey(group, key));
+        redissonClient.getLock(getLockKey(group, key)).unlock();
+    }
+
+    private static String getLockKey(Object group, Object key) {
+        return "LOCK:" + group.toString() + "-" + key.toString();
+    }
+
+}

--- a/src/main/java/com/jhsfully/inventoryManagement/restcontroller/InboundController.java
+++ b/src/main/java/com/jhsfully/inventoryManagement/restcontroller/InboundController.java
@@ -1,18 +1,24 @@
 package com.jhsfully.inventoryManagement.restcontroller;
 
 import com.jhsfully.inventoryManagement.dto.InboundDto;
+import com.jhsfully.inventoryManagement.dto.InboundDto.InboundResponse;
 import com.jhsfully.inventoryManagement.facade.InboundFacade;
 import com.jhsfully.inventoryManagement.lock.ProcessLock;
 import com.jhsfully.inventoryManagement.service.InboundInterface;
 import com.jhsfully.inventoryManagement.type.LockType;
+import java.time.LocalDate;
 import lombok.AllArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.*;
-
-import java.time.LocalDate;
-import java.util.concurrent.locks.Lock;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @AllArgsConstructor
@@ -37,7 +43,7 @@ public class InboundController {
         return ResponseEntity.ok(inboundService.getInboundsByPurchase(purchaseId));
     }
 
-    @ProcessLock(value = LockType.PURCHASE_INBOUND, key = "request.purchaseId")
+    @ProcessLock(group = LockType.PURCHASE_INBOUND, key = "#request.purchaseId")
     @PostMapping("")
     @PreAuthorize("hasRole('INBOUND_MANAGE')")
     public ResponseEntity<?> executeInbound(@RequestBody InboundDto.InboundOuterAddRequest request){
@@ -47,7 +53,8 @@ public class InboundController {
     @DeleteMapping("/{id}")
     @PreAuthorize("hasRole('INBOUND_MANAGE')")
     public ResponseEntity<?> cancelInbound(@PathVariable Long id){
-        inboundFacade.cancelInbound(id);
+        InboundResponse inboundResponse = inboundService.getInbound(id);
+        inboundFacade.cancelInbound(id, inboundResponse.getStockId());
         return ResponseEntity.ok(id);
     }
 

--- a/src/main/java/com/jhsfully/inventoryManagement/restcontroller/PurchaseController.java
+++ b/src/main/java/com/jhsfully/inventoryManagement/restcontroller/PurchaseController.java
@@ -3,17 +3,20 @@ package com.jhsfully.inventoryManagement.restcontroller;
 import com.jhsfully.inventoryManagement.dto.PurchaseDto;
 import com.jhsfully.inventoryManagement.lock.ProcessLock;
 import com.jhsfully.inventoryManagement.service.PurchaseInterface;
-import com.jhsfully.inventoryManagement.service.PurchaseService;
 import com.jhsfully.inventoryManagement.type.LockType;
+import java.time.LocalDate;
 import lombok.AllArgsConstructor;
-import org.apache.coyote.Response;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.*;
-
-import java.time.LocalDate;
-import java.time.LocalDateTime;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @AllArgsConstructor
@@ -35,7 +38,7 @@ public class PurchaseController {
         return ResponseEntity.ok(purchaseService.addPurchase(request));
     }
 
-    @ProcessLock(value = LockType.PURCHASE_INBOUND, key = "id")
+    @ProcessLock(group = LockType.PURCHASE_INBOUND, key = "#id")
     @DeleteMapping("/{id}")
     @PreAuthorize("hasRole('PURCHASE_MANAGE')")
     public ResponseEntity<?> deletePurchase(@PathVariable Long id){

--- a/src/main/java/com/jhsfully/inventoryManagement/service/BomInterface.java
+++ b/src/main/java/com/jhsfully/inventoryManagement/service/BomInterface.java
@@ -6,18 +6,18 @@ import java.util.List;
 
 public interface BomInterface {
 
-    public List<BomDto.BomTopResponse> getBoms();
+    List<BomDto.BomTopResponse> getBoms();
 
-    public BomDto.BomTreeResponse getBom(Long pid);
+    BomDto.BomTreeResponse getBom(Long pid);
 
-    public List<BomDto.BomLeaf> getLeafProducts(Long id);
+    List<BomDto.BomLeaf> getLeafProducts(Long id);
 
-    public BomDto.BomResponse addBom(BomDto.BomAddRequest request);
+    BomDto.BomResponse addBom(BomDto.BomAddRequest request);
 
-    public void updateBomNode(BomDto.BomUpdateRequest request);
+    void updateBomNode(BomDto.BomUpdateRequest request);
 
-    public void deleteBomNode(Long bid);
+    void deleteBomNode(Long bid);
 
-    public void deleteBomTree(Long pid);
+    void deleteBomTree(Long pid);
 
 }

--- a/src/main/java/com/jhsfully/inventoryManagement/service/OutboundInterface.java
+++ b/src/main/java/com/jhsfully/inventoryManagement/service/OutboundInterface.java
@@ -6,19 +6,19 @@ import java.time.LocalDate;
 import java.util.List;
 
 public interface OutboundInterface {
-    public Double countByStock(Long stockId);
+    Double countByStock(Long stockId);
 
-    public List<OutboundDto.OutboundResponse> getOutbounds(LocalDate startDate,
+    List<OutboundDto.OutboundResponse> getOutbounds(LocalDate startDate,
                                                            LocalDate endDate);
 
-    public List<OutboundDto.OutboundDetailResponse> getOutboundDetails(Long outboundId);
+    List<OutboundDto.OutboundDetailResponse> getOutboundDetails(Long outboundId);
 
-    public OutboundDto.OutboundResponse addOutbound(OutboundDto.OutboundAddRequest request);
+    OutboundDto.OutboundResponse addOutbound(OutboundDto.OutboundAddRequest request);
 
-    public void addOutboundDetail(OutboundDto.OutboundDetailAddRequest request);
+    void addOutboundDetail(OutboundDto.OutboundDetailAddRequest request);
 
-    public void deleteOutbound(Long outboundId);
+    void deleteOutbound(Long outboundId);
 
-    public OutboundDto.OutboundDetailResponse deleteOutboundDetail(Long detailId);
+    OutboundDto.OutboundDetailResponse deleteOutboundDetail(Long detailId);
 
 }

--- a/src/main/java/com/jhsfully/inventoryManagement/service/PlanInterface.java
+++ b/src/main/java/com/jhsfully/inventoryManagement/service/PlanInterface.java
@@ -7,12 +7,12 @@ import java.util.List;
 
 public interface PlanInterface {
 
-    public List<PlanDto.PlanResponse> getPlans(LocalDate startdate, LocalDate enddate);
+    List<PlanDto.PlanResponse> getPlans(LocalDate startdate, LocalDate enddate);
 
-    public PlanDto.PlanResponse addPlan(PlanDto.PlanAddRequest request);
+    PlanDto.PlanResponse addPlan(PlanDto.PlanAddRequest request);
 
-    public PlanDto.PlanResponse updatePlan(PlanDto.PlanUpdateRequest request);
+    PlanDto.PlanResponse updatePlan(PlanDto.PlanUpdateRequest request);
 
-    public void deletePlan(Long id);
+    void deletePlan(Long id);
 
 }

--- a/src/main/java/com/jhsfully/inventoryManagement/service/ProductInterface.java
+++ b/src/main/java/com/jhsfully/inventoryManagement/service/ProductInterface.java
@@ -6,15 +6,15 @@ import java.util.List;
 
 public interface ProductInterface {
 
-    public ProductDto.ProductResponse getProduct(Long id);
-    public List<ProductDto.ProductResponse> getAllProducts();
-    public List<ProductDto.ProductResponse> getProducts();
+    ProductDto.ProductResponse getProduct(Long id);
+    List<ProductDto.ProductResponse> getAllProducts();
+    List<ProductDto.ProductResponse> getProducts();
 
-    public ProductDto.ProductResponse addProduct(ProductDto.ProductAddRequest request);
+    ProductDto.ProductResponse addProduct(ProductDto.ProductAddRequest request);
 
-    public ProductDto.ProductResponse updateProduct(ProductDto.ProductUpdateRequest request);
+    ProductDto.ProductResponse updateProduct(ProductDto.ProductUpdateRequest request);
 
-    public void disableProduct(Long id);
-    public void deleteProduct(Long id);
+    void disableProduct(Long id);
+    void deleteProduct(Long id);
 
 }

--- a/src/main/java/com/jhsfully/inventoryManagement/service/PurchaseInterface.java
+++ b/src/main/java/com/jhsfully/inventoryManagement/service/PurchaseInterface.java
@@ -1,18 +1,16 @@
 package com.jhsfully.inventoryManagement.service;
 
 import com.jhsfully.inventoryManagement.dto.PurchaseDto;
-
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
 
 public interface PurchaseInterface {
 
-    public PurchaseDto.PurchaseResponse getPurchase(Long id);
-    public List<PurchaseDto.PurchaseResponse> getPurchases(LocalDate startDate, LocalDate endDate);
+    PurchaseDto.PurchaseResponse getPurchase(Long id);
+    List<PurchaseDto.PurchaseResponse> getPurchases(LocalDate startDate, LocalDate endDate);
 
-    public PurchaseDto.PurchaseResponse addPurchase(PurchaseDto.PurchaseAddRequest request);
+    PurchaseDto.PurchaseResponse addPurchase(PurchaseDto.PurchaseAddRequest request);
 
-    public void deletePurchase(Long id);
+    void deletePurchase(Long id);
 
 }

--- a/src/main/java/com/jhsfully/inventoryManagement/service/StocksInterface.java
+++ b/src/main/java/com/jhsfully/inventoryManagement/service/StocksInterface.java
@@ -5,22 +5,22 @@ import com.jhsfully.inventoryManagement.dto.StocksDto;
 import java.util.List;
 
 public interface StocksInterface {
-    public StocksDto.StockResponseLot getStock(Long id);
+    StocksDto.StockResponseLot getStock(Long id);
 
-    public List<StocksDto.StockGroupResponse> getAllStocks();
+    List<StocksDto.StockGroupResponse> getAllStocks();
 
-    public List<StocksDto.StockResponseLot> getLotByPid(Long productid);
+    List<StocksDto.StockResponseLot> getLotByPid(Long productid);
 
-    public StocksDto.StockResponseLot addStock(StocksDto.StockAddRequest request);
+    StocksDto.StockResponseLot addStock(StocksDto.StockAddRequest request);
 
-    public void setInbound(Long stockId, Long inboundId);
+    void setInbound(Long stockId, Long inboundId);
 
-    public void releaseInbound(Long stockId);
+    void releaseInbound(Long stockId);
 
-    public void spendStockById(Long id, Double amount);
+    void spendStockById(Long id, Double amount);
 
-    public void cancelSpendStockById(Long id, Double amount);
+    void cancelSpendStockById(Long id, Double amount);
 
-    public void deleteStock(Long id);
+    void deleteStock(Long id);
 
 }

--- a/src/test/java/com/jhsfully/inventoryManagement/facade/InboundFacadeTest.java
+++ b/src/test/java/com/jhsfully/inventoryManagement/facade/InboundFacadeTest.java
@@ -1,26 +1,32 @@
 package com.jhsfully.inventoryManagement.facade;
 
+import static com.jhsfully.inventoryManagement.type.InboundErrorType.INBOUND_EXCEED_PURCHASE_AMOUNT;
+import static com.jhsfully.inventoryManagement.type.InboundErrorType.INBOUND_NOT_FOUND;
+import static com.jhsfully.inventoryManagement.type.StocksErrorType.STOCKS_NOT_FOUND;
+import static com.jhsfully.inventoryManagement.type.StocksErrorType.STOCKS_OCCURRED_OUTBOUND;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import com.jhsfully.inventoryManagement.dto.InboundDto;
 import com.jhsfully.inventoryManagement.dto.StocksDto;
 import com.jhsfully.inventoryManagement.exception.InboundException;
 import com.jhsfully.inventoryManagement.exception.StocksException;
 import com.jhsfully.inventoryManagement.service.InboundInterface;
 import com.jhsfully.inventoryManagement.service.StocksInterface;
-import org.junit.jupiter.api.*;
+import java.sql.Connection;
+import java.sql.SQLException;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.jdbc.datasource.init.ScriptUtils;
-
-import javax.sql.DataSource;
-import java.sql.Connection;
-import java.sql.SQLException;
-
-import static com.jhsfully.inventoryManagement.type.InboundErrorType.INBOUND_EXCEED_PURCHASE_AMOUNT;
-import static com.jhsfully.inventoryManagement.type.InboundErrorType.INBOUND_NOT_FOUND;
-import static com.jhsfully.inventoryManagement.type.StocksErrorType.STOCKS_NOT_FOUND;
-import static com.jhsfully.inventoryManagement.type.StocksErrorType.STOCKS_OCCURRED_OUTBOUND;
-import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
@@ -86,7 +92,7 @@ class InboundFacadeTest {
     @DisplayName("[Facade] 입고 취소 성공")
     void cancelInboundSuccess(){
         //when
-        inboundFacade.cancelInbound(7L);
+        inboundFacade.cancelInbound(7L, 7L);
         //then
         InboundException exceptionI = assertThrows(InboundException.class,
                 () -> inboundService.getInbound(7L));
@@ -123,7 +129,7 @@ class InboundFacadeTest {
     void cancelInboundFail(){
         //when
         StocksException exception = assertThrows(StocksException.class,
-                () -> inboundFacade.cancelInbound(1L));
+                () -> inboundFacade.cancelInbound(1L, 1L));
         //then
         assertEquals(STOCKS_OCCURRED_OUTBOUND, exception.getStocksErrorType());
     }

--- a/src/test/java/com/jhsfully/inventoryManagement/restcontroller/InboundControllerTest.java
+++ b/src/test/java/com/jhsfully/inventoryManagement/restcontroller/InboundControllerTest.java
@@ -1,11 +1,29 @@
 package com.jhsfully.inventoryManagement.restcontroller;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jhsfully.inventoryManagement.dto.InboundDto;
+import com.jhsfully.inventoryManagement.dto.InboundDto.InboundResponse;
 import com.jhsfully.inventoryManagement.facade.InboundFacade;
 import com.jhsfully.inventoryManagement.security.JwtAuthenticationFilter;
 import com.jhsfully.inventoryManagement.security.SecurityConfiguration;
 import com.jhsfully.inventoryManagement.service.InboundInterface;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -16,21 +34,6 @@ import org.springframework.context.annotation.FilterType;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
-
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.Arrays;
-
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(value = InboundController.class, excludeFilters =
     @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {
@@ -138,6 +141,10 @@ class InboundControllerTest {
     @DisplayName("[Controller]입고 취소 성공")
     void cancelInboundSuccess() throws Exception {
 
+        //given
+        given(inboundService.getInbound(anyLong()))
+            .willReturn(InboundResponse.builder().stockId(1L).build());
+
         //when & then
         mockMvc.perform(delete("/inbound/1")
                         .with(csrf()))
@@ -145,7 +152,7 @@ class InboundControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(content().string("1"));
 
-        verify(inboundFacade, times(1)).cancelInbound(anyLong());
+        verify(inboundFacade, times(1)).cancelInbound(anyLong(), anyLong());
 
     }
 }


### PR DESCRIPTION
- LettuceLock으로 SpinLock으로 Lock을 걸었지만, 이는 비효율적인 Lock이라 Redisson Client를 사용하는  Lock으로 변경함.
- Lock이 점유되고 내부적으로 수행되는 로직은 바로 DB에 Commit이 되도록 전파옵션을 REQUIRES_NEW로 지정함.
- Interface에 불필요한 public 접근제한자 제거.
- Dto클래스에 빈생성자 추가.